### PR TITLE
Typo fix: Generate -> General

### DIFF
--- a/content/language/index.md
+++ b/content/language/index.md
@@ -2,7 +2,7 @@ title: Language
 layout: default.liquid
 ---
 
-Generate posts about the Rust programming language.
+General posts about the Rust programming language.
 
 <h2>
   Posts


### PR DESCRIPTION
Although a category generating the posts itself would be much less work!