### PR TITLE
Add tweet tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /public
 .mastodon-data.json
-.twitter-data.json
+.twitter-data.txt
+src/bin/.consumer*
 /target/
 **/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /public
 .mastodon-data.json
-.twitter-data.txt
+.twitter-data.json
 src/bin/.consumer*
 /target/
 **/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /public
 .mastodon-data.json
+.twitter-data.json
 /target/
 **/*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 cache: cargo
 install: '[ "`cobalt --version`" == "Cobalt 0.11.1" ] || cargo install --force cobalt-bin'
 script:
+  - 'echo consumer_key > src/bin/.consumer_key; echo consumer_secret > src/bin/.consumer_secret'
   - cargo test
   - make
 rust:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,21 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "antidote"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayref"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -80,8 +93,22 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -118,6 +145,11 @@ dependencies = [
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "core-foundation"
@@ -183,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,9 +276,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "egg-mode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -273,6 +343,11 @@ dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "feedfinder"
@@ -340,9 +415,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hmac"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "html5ever"
@@ -587,6 +681,14 @@ dependencies = [
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
@@ -865,6 +967,7 @@ version = "0.1.0"
 dependencies = [
  "atom_syndication 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "egg-mode 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "feedfinder 0.1.0 (git+https://github.com/wezm/feedfinder.git)",
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "kuchiki 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,6 +984,23 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1049,6 +1169,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1305,23 @@ dependencies = [
  "futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1345,6 +1494,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1558,11 @@ dependencies = [
 [[package]]
 name = "utf-8"
 version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1470,7 +1629,9 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+"checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atom_syndication 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "03a192fe1118b1a3b96e9e1dd2057aa54ad142e7cf4c92b0f5b2900069e785af"
 "checksum backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe525f66f42d207968308ee86bc2dd60aa5fab535b22e616323a173d097d8e"
@@ -1480,12 +1641,15 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
 "checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -1493,16 +1657,20 @@ dependencies = [
 "checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
+"checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
 "checksum cssparser 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef6124306e5ebc5ab11891d063aeafdd0cdc308079b708c8b566125f3680292b"
 "checksum cssparser-macros 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a5383ae18dbfdeb569ed62019f5bddb2a95cd2d3833313c475a0d014777805"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum derive_builder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c998e6ab02a828dd9735c18f154e14100e674ed08cb4e1938f0e4177543f439"
 "checksum derive_builder_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "735e24ee9e5fa8e16b86da5007856e97d592e11867e45d76e0c0d0a164a0b757"
+"checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum egg-mode 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b268cd96a3680c07efa1aed45f054d3c8075e5432d7cc82ef6ded95c76c41609"
 "checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum feedfinder 0.1.0 (git+https://github.com/wezm/feedfinder.git)" = "<none>"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -1512,7 +1680,9 @@ dependencies = [
 "checksum futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "51f93f3de6ba1794dcd5810b3546d004600a59a98266487c8407bc4b24e398f3"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
+"checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
 "checksum html5ever 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a49d5001dd1bddf042ea41ed4e0a671d50b1bf187e66b349d7ec613bdce4ad90"
 "checksum html5ever 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bfb46978eb757a603b7dfe2dafb1c62cb4dee3428d8ac1de734d83d6b022d06"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
@@ -1539,6 +1709,7 @@ dependencies = [
 "checksum markup5ever 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff834ac7123c6a37826747e5ca09db41fd7a83126792021c2e636ad174bb77d3"
 "checksum markup5ever 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "047150a0e03b57e638fc45af33a0b63a0362305d5b9f92ecef81df472a4cceb0"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -1571,6 +1742,8 @@ dependencies = [
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
@@ -1589,6 +1762,7 @@ dependencies = [
 "checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
+"checksum sha-1 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4172176a276b62241556af0cf0c58a2dd6625cfc01a4d0bb59dc0db43e0c319d"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
@@ -1605,6 +1779,8 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tendril 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1b72f8e2f5b73b65c315b1a70c730f24b9d7a25f39e98de8acbe2bb795caea"
 "checksum tendril 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9de21546595a0873061940d994bbbc5c35f024ae4fd61ec5c5b159115684f508"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "be15ef40f675c9fe66e354d74c73f3ed012ca1aa14d65846a33ee48f1ae8d922"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
@@ -1620,6 +1796,7 @@ dependencies = [
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -1629,6 +1806,7 @@ dependencies = [
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf-8 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1262dfab4c30d5cb7c07026be00ee343a6cf5027fdc0104a9160f354e5db75c"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,8 @@ dependencies = [
  "atom_syndication 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "egg-mode 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "feedfinder 0.1.0 (git+https://github.com/wezm/feedfinder.git)",
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "kuchiki 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Wesley Moore <wes@wezm.net>"]
 [dependencies]
 atom_syndication = "0.5"
 chrono = { version = "0.4.0", features = ['serde'] }
+egg-mode = "0.12"
 feedfinder = { git = "https://github.com/wezm/feedfinder.git" }
 getopts = "0.2"
 kuchiki = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ rss = "1.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+tokio-core = "0.1"
 uuid = { version = "0.5", features = ['v4', 'serde'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["Wesley Moore <wes@wezm.net>"]
 atom_syndication = "0.5"
 chrono = { version = "0.4.0", features = ['serde'] }
 egg-mode = "0.12"
+failure = "0.1"
+failure_derive = "0.1"
 feedfinder = { git = "https://github.com/wezm/feedfinder.git" }
 getopts = "0.2"
 kuchiki = "0.6"

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ feeds:
 deploy: all
 	aws s3 sync --delete --cache-control 'max-age=120, public' public s3://readrust.net
 	cargo run --release --bin toot -- content/_data/tooted.json content/_data/rust/posts.json
-
+	cargo run --release --bin tweet -- content/_data/tweeted content/_data/rust/posts.json

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ feeds:
 deploy: all
 	aws s3 sync --delete --cache-control 'max-age=120, public' public s3://readrust.net
 	cargo run --release --bin toot -- content/_data/tooted.json content/_data/rust/posts.json
-	cargo run --release --bin tweet -- content/_data/tweeted content/_data/rust/posts.json
+	cargo run --release --bin tweet -- content/_data/tweeted.json content/_data/rust/posts.json

--- a/content/_data/tweeted.json
+++ b/content/_data/tweeted.json
@@ -1,0 +1,1172 @@
+[
+  {
+    "item_id": "04fdf0c8-05ab-46f3-b72d-c7e88eb6dc9b"
+  },
+  {
+    "item_id": "1054cc8a-cbdd-4073-b7f9-2801aaad6fd6"
+  },
+  {
+    "item_id": "07825eb3-aaab-46c5-b7e4-680857d73750"
+  },
+  {
+    "item_id": "fe44a6a6-04fd-42f7-a0ee-c816282bac5e"
+  },
+  {
+    "item_id": "d4574214-e1ca-4fe8-858b-b5c9c64046ab"
+  },
+  {
+    "item_id": "9f012379-d71a-4c45-b9db-12c4871070e7"
+  },
+  {
+    "item_id": "cfc59513-ea0b-4d61-ac46-d7ea2e5bba8b"
+  },
+  {
+    "item_id": "b33165a2-c60c-4431-872d-4528770e42c1"
+  },
+  {
+    "item_id": "eef1f270-fb75-475a-b10c-8e3813990362"
+  },
+  {
+    "item_id": "ad4ba620-3dae-4618-abc7-e245c97369d3"
+  },
+  {
+    "item_id": "348de5bf-0fa7-48d1-b112-20cd13cfd3f3"
+  },
+  {
+    "item_id": "bf2c60f0-b2be-44c4-ba38-dce0f5b2e041"
+  },
+  {
+    "item_id": "a15836bc-6eaf-46c9-8fe8-70bd2fada61e"
+  },
+  {
+    "item_id": "e0dec9da-faee-4dcd-bfd2-8e14dda4f3f6"
+  },
+  {
+    "item_id": "9e02b413-b1dd-42a3-a970-2d7b89354c0c"
+  },
+  {
+    "item_id": "6cf2d39d-3ea9-4af4-b9c7-a368be610189"
+  },
+  {
+    "item_id": "93eaac73-c49e-4d21-8d11-f9ca7e40721c"
+  },
+  {
+    "item_id": "c57dc18b-48b9-453e-b44a-46da4dce6d8e"
+  },
+  {
+    "item_id": "afdcd322-eab4-4363-be76-cecaa050e867"
+  },
+  {
+    "item_id": "73cbd270-d16d-4aec-b38d-9503961891bd"
+  },
+  {
+    "item_id": "f860801f-7b99-4fe3-88cc-a6c00ca7d97a"
+  },
+  {
+    "item_id": "e32bb679-4afa-48d9-ab51-d589a590348e"
+  },
+  {
+    "item_id": "8bd1d21c-79d1-4470-9d49-907c26ab0057"
+  },
+  {
+    "item_id": "03cf26ef-4e0f-4124-91ec-064467299583"
+  },
+  {
+    "item_id": "c5aa834d-c9d6-4e24-8abf-a9db4cb5cf29"
+  },
+  {
+    "item_id": "dae19f32-236c-4329-b26d-e6c47b2631d3"
+  },
+  {
+    "item_id": "908c4bee-bf00-4e80-8136-9282eb8de6f6"
+  },
+  {
+    "item_id": "655ac748-e1e9-4fa4-b12a-2dc7c2e88fa7"
+  },
+  {
+    "item_id": "1fe95cfd-488a-41a5-adca-a44d8f79c679"
+  },
+  {
+    "item_id": "465a729e-a243-4cd7-bee8-e0c7d5d09fbd"
+  },
+  {
+    "item_id": "17b6e878-388f-40c5-93a0-cf3da64a1078"
+  },
+  {
+    "item_id": "f1b7c59f-fff8-4000-ac97-2be742b86760"
+  },
+  {
+    "item_id": "44e96573-f8b3-4577-8a76-1cbc8a65ec8b"
+  },
+  {
+    "item_id": "f5ba053a-1bbb-465d-a430-55bd0a1d357a"
+  },
+  {
+    "item_id": "81e14040-a499-4802-9d1b-c58deeb2be79"
+  },
+  {
+    "item_id": "a4faa45e-f24e-4ce9-822c-5c4623919e17"
+  },
+  {
+    "item_id": "eabc9692-30cf-4511-89f4-9068b46aadd8"
+  },
+  {
+    "item_id": "24afdde0-ef13-4e26-b39e-b2f9d52ab901"
+  },
+  {
+    "item_id": "39f186f6-b177-43e6-9b4c-7ffe689926e7"
+  },
+  {
+    "item_id": "bf12d6fd-0aea-4d74-b3a7-02a538d210d3"
+  },
+  {
+    "item_id": "249e8bc3-a836-4b71-89b6-8d7c4d1b0977"
+  },
+  {
+    "item_id": "962abf61-6061-4e8d-90b1-1d3ba90d5e1d"
+  },
+  {
+    "item_id": "a48d8156-7f0f-4731-a17b-e36678b86f5f"
+  },
+  {
+    "item_id": "85524257-1035-4e25-b20b-57737d314b55"
+  },
+  {
+    "item_id": "4ed8ee1b-6f71-4ac5-b7e5-142509562231"
+  },
+  {
+    "item_id": "4d94c5ba-199d-44c2-9148-7a6bbff699d0"
+  },
+  {
+    "item_id": "90d39fbf-c75d-4943-9069-4b65d11b1be9"
+  },
+  {
+    "item_id": "e03aa0e5-bb05-48f0-a4a4-0796d14d1115"
+  },
+  {
+    "item_id": "9ecf3a00-a806-4914-a3e2-fd360f7199ed"
+  },
+  {
+    "item_id": "bd4b8e12-dd4d-4bf8-b553-f5f912ec4e87"
+  },
+  {
+    "item_id": "db7ea4c5-14ae-4a9d-9bf4-a314c20225f7"
+  },
+  {
+    "item_id": "f6bf64c8-3a31-4614-ba91-f5c16a0986b5"
+  },
+  {
+    "item_id": "44f7fa8d-b23d-47e7-b3dd-f227e8317d49"
+  },
+  {
+    "item_id": "0d2f8636-6f6c-42f3-8159-beac5a856009"
+  },
+  {
+    "item_id": "fd8646cf-2689-4bd8-b065-4708388250d2"
+  },
+  {
+    "item_id": "64fe2d3c-c0cb-41a2-8faf-08d19e59c439"
+  },
+  {
+    "item_id": "c35de4ff-df45-4774-998f-f56ddb57b5d2"
+  },
+  {
+    "item_id": "dd5790e1-ff4e-4f61-9a8b-05ea774a2e89"
+  },
+  {
+    "item_id": "8da41ef1-4c51-4269-bec3-fc377a0f387f"
+  },
+  {
+    "item_id": "79704e4b-5e9f-4366-84a8-53d5a3431e2f"
+  },
+  {
+    "item_id": "bd7d2caa-818d-4950-9eca-72588b038bed"
+  },
+  {
+    "item_id": "5b0beffe-60dc-4ce3-b137-738fb51fd570"
+  },
+  {
+    "item_id": "0c9a85c5-9017-4922-b07a-050f36b8db84"
+  },
+  {
+    "item_id": "776dd5f1-c6d0-48da-8e0a-6fcae00fb923"
+  },
+  {
+    "item_id": "85925a6b-30c1-4c0f-8caf-b6ccd9e3e19c"
+  },
+  {
+    "item_id": "c59a9688-62e5-4919-8687-e5ff82c3c5a3"
+  },
+  {
+    "item_id": "95bd2ff7-1a99-4092-931a-b17d782282d3"
+  },
+  {
+    "item_id": "39d1ac9b-501b-46c3-b2e6-68f2d4aabe1d"
+  },
+  {
+    "item_id": "ae89c8c8-fd8f-4432-9b21-1a2651142869"
+  },
+  {
+    "item_id": "2f386775-d0a5-474b-a9de-c14af7453c40"
+  },
+  {
+    "item_id": "407d3ba2-d0af-4121-b13a-468b1f0f66cd"
+  },
+  {
+    "item_id": "4c17c0f4-8148-4408-a54f-733e20c89189"
+  },
+  {
+    "item_id": "3907940b-eb06-4f2a-a3ff-6df4ae5ac9ca"
+  },
+  {
+    "item_id": "ab076ead-649f-47ff-8fa2-a7c243ba3dca"
+  },
+  {
+    "item_id": "257617e2-c1fe-44c7-9cb9-7c07495b96ec"
+  },
+  {
+    "item_id": "ca98f7f9-8927-48e9-8028-15e81f20f8a6"
+  },
+  {
+    "item_id": "d377bc0d-a127-456d-81fa-926fe634de0f"
+  },
+  {
+    "item_id": "0ebef41d-c7b1-424a-a120-ebf1098bbe38"
+  },
+  {
+    "item_id": "d001ce02-fbfb-4a08-8389-0f713b09bf72"
+  },
+  {
+    "item_id": "067e3ce9-6e69-499c-93f8-a9c4e0f99ce9"
+  },
+  {
+    "item_id": "75898724-f900-46ae-877b-36d87b440ac1"
+  },
+  {
+    "item_id": "cec6c9fd-a92b-4f5a-8d9b-9b84c263c48f"
+  },
+  {
+    "item_id": "0cb6b35f-0d4f-4e71-bcae-66d4cd115d41"
+  },
+  {
+    "item_id": "5e572868-98d0-4944-b897-14cca13a39a4"
+  },
+  {
+    "item_id": "26bc7432-d561-4e1f-8cf2-2c30b8ac63ab"
+  },
+  {
+    "item_id": "504ed65c-1efe-4cbd-b655-b17e89110936"
+  },
+  {
+    "item_id": "34ee0b77-cabd-47a8-bb6c-00e8a34046c7"
+  },
+  {
+    "item_id": "0493daa3-4abb-46eb-82de-e75daea4bbac"
+  },
+  {
+    "item_id": "516e4eaf-1ce1-49be-a457-a471e9f97329"
+  },
+  {
+    "item_id": "b079d66f-d08e-4593-80cc-e0060133d12e"
+  },
+  {
+    "item_id": "22d134e6-ddc6-4571-965c-4b6e72a544eb"
+  },
+  {
+    "item_id": "450ba7fc-c3ea-4af5-bda4-06842f062de8"
+  },
+  {
+    "item_id": "c5a101b5-e749-4e99-9e08-54de2cf0a2c1"
+  },
+  {
+    "item_id": "0d46d60e-49c7-44ce-8f0c-48b94501b1ca"
+  },
+  {
+    "item_id": "45772a5b-1f22-4db9-9eee-f888c0c82660"
+  },
+  {
+    "item_id": "3dc17991-d359-4205-917a-80b37a564b37"
+  },
+  {
+    "item_id": "8e33c7c4-2788-418b-8e47-ca8990ae0d38"
+  },
+  {
+    "item_id": "b2eb24c3-d7ee-438c-b041-0446dd551abe"
+  },
+  {
+    "item_id": "f2bf66c3-52bf-4a3c-b508-96bbd3385e8d"
+  },
+  {
+    "item_id": "c078b1d0-a902-42c5-84d0-5d262146e64c"
+  },
+  {
+    "item_id": "9b97498f-3ffb-4c89-8973-c2beb5e0140e"
+  },
+  {
+    "item_id": "25d98aac-94a1-4cda-bbdb-7b22b76ed032"
+  },
+  {
+    "item_id": "5ecd2c77-20dd-4fd5-84a7-6c8e2364ebde"
+  },
+  {
+    "item_id": "e5f704af-b1ed-4757-b96d-80402ba3e601"
+  },
+  {
+    "item_id": "6d0e61c5-087e-48dc-abd8-ded4f3e43a8a"
+  },
+  {
+    "item_id": "44ef6094-b3df-4a2c-9cd9-429feecff6bc"
+  },
+  {
+    "item_id": "f77cc701-eca9-4b85-a450-dd10c1766966"
+  },
+  {
+    "item_id": "ff94e8a6-c203-4cbe-af46-8f99e2896dd8"
+  },
+  {
+    "item_id": "4abf1536-2c82-411a-be74-e85d2155af5a"
+  },
+  {
+    "item_id": "45c32609-24ef-4288-b361-57ca8b5a34cd"
+  },
+  {
+    "item_id": "a2946d73-a2c7-4d2a-899c-080258552b07"
+  },
+  {
+    "item_id": "c780f270-e190-4987-aff1-ff20ebe108bf"
+  },
+  {
+    "item_id": "6a1644f0-2b9e-4c82-9ccd-ef69815f560f"
+  },
+  {
+    "item_id": "938457b4-8905-4954-9007-88c80a2c24d6"
+  },
+  {
+    "item_id": "0af4c90e-74b2-438d-aaed-798c9f6e900a"
+  },
+  {
+    "item_id": "1694fd36-21ca-4e3f-8654-9291c3ba4de7"
+  },
+  {
+    "item_id": "86b2dfcd-a01d-47e1-acb8-2ddbca20db62"
+  },
+  {
+    "item_id": "bbc46982-1321-4e4e-8d9f-344963341c21"
+  },
+  {
+    "item_id": "35c70f95-6097-47df-a470-bb92e99b27e5"
+  },
+  {
+    "item_id": "2b698c99-99e0-4fad-8716-b58dbd9c255c"
+  },
+  {
+    "item_id": "751253b7-494d-4930-9586-40c18cab9280"
+  },
+  {
+    "item_id": "49ad5651-12e0-4374-9586-d9a86291c165"
+  },
+  {
+    "item_id": "019b1da3-b979-478b-89ed-7824c75df122"
+  },
+  {
+    "item_id": "b8e85b25-1d33-4b69-a3ba-b2cbac2bf62e"
+  },
+  {
+    "item_id": "28ce1b60-8837-4443-87fb-669bf176db9b"
+  },
+  {
+    "item_id": "c7a9c9d2-8858-4f47-afa3-19ec1f2f6b86"
+  },
+  {
+    "item_id": "325af8a8-af88-4a07-9c8f-16d2865f01f3"
+  },
+  {
+    "item_id": "6b542e90-1f02-4368-90e4-a1931ccf1935"
+  },
+  {
+    "item_id": "b7290658-fff8-4ee5-b8e5-eceefdc6beb6"
+  },
+  {
+    "item_id": "4924a3b4-b71f-4a15-ae2d-0a77bcb30e98"
+  },
+  {
+    "item_id": "29eb1ede-d551-4b8d-aeec-c673aafb7e8f"
+  },
+  {
+    "item_id": "e6347974-c84a-438a-924a-52ef37f6c99a"
+  },
+  {
+    "item_id": "94324d77-490d-4897-bfd7-5a5b7c4c0cfb"
+  },
+  {
+    "item_id": "b0a2bc9c-effa-4859-b804-cbe839060855"
+  },
+  {
+    "item_id": "ac0c5546-f21b-4b47-b4a4-950464472aad"
+  },
+  {
+    "item_id": "60238a1c-95ee-46d8-bf5c-e70fed87a103"
+  },
+  {
+    "item_id": "6e3c698d-7f42-43d4-9c08-2ee084945e5c"
+  },
+  {
+    "item_id": "5e5df82f-aba3-4832-bbe6-e995b2e544ef"
+  },
+  {
+    "item_id": "c0b3d7ad-673f-4eb9-aa54-45447d1eafb0"
+  },
+  {
+    "item_id": "92664a59-08e0-4185-aab2-cd0a29f303f8"
+  },
+  {
+    "item_id": "f4e99fe5-2dab-418d-9256-813a75036164"
+  },
+  {
+    "item_id": "25060712-7d38-4492-991d-a52a9111891c"
+  },
+  {
+    "item_id": "434c400b-b4ac-49c9-87fa-db2a8b5f1ba7"
+  },
+  {
+    "item_id": "303b0429-9b0c-46f8-a555-fbab8c2bdf90"
+  },
+  {
+    "item_id": "b4def99b-cdec-46c6-9816-a6c85c999ae9"
+  },
+  {
+    "item_id": "c73d7d0b-4f7a-4448-acee-d98dbb499461"
+  },
+  {
+    "item_id": "4aeb0aa5-6a72-41c9-87bc-a2e24b5e33d3"
+  },
+  {
+    "item_id": "b8c9dfda-526c-453c-a93b-5c96a207643e"
+  },
+  {
+    "item_id": "444386e2-51fc-488e-ac19-0aa71a4d89a3"
+  },
+  {
+    "item_id": "93d7f09d-e1eb-4d6a-a792-5765326730be"
+  },
+  {
+    "item_id": "d2fc34d4-c1ec-4c3d-8e39-b420b8f20fe8"
+  },
+  {
+    "item_id": "1ccb8993-1118-4eb4-a1fb-0c6146948662"
+  },
+  {
+    "item_id": "0cced83f-3736-4917-87a0-408fb4d9f6bb"
+  },
+  {
+    "item_id": "5c8f0581-5b1d-485b-852c-83c0deef73d5"
+  },
+  {
+    "item_id": "2168f429-844d-4629-97da-c149e9026cfd"
+  },
+  {
+    "item_id": "e1a29851-ab4c-4739-a41f-56e9c783f5e4"
+  },
+  {
+    "item_id": "d4191312-2442-4eb8-b313-67ba224829b6"
+  },
+  {
+    "item_id": "fb492342-c776-4f9a-8792-d82efebf109f"
+  },
+  {
+    "item_id": "99cd44d4-1722-4d1e-a002-693fac055af1"
+  },
+  {
+    "item_id": "cdf001ee-aea6-47e3-be58-527a3b7fdc08"
+  },
+  {
+    "item_id": "c752755c-985e-44d4-a15f-1dac8fffa86c"
+  },
+  {
+    "item_id": "b02d9dda-9c01-481b-8111-0241bf8e99d4"
+  },
+  {
+    "item_id": "e200a902-0b10-41fa-99ce-241d38311eea"
+  },
+  {
+    "item_id": "9de23e26-5e53-4569-afb2-0576494c75f5"
+  },
+  {
+    "item_id": "9a9ed680-6525-4c70-ae8a-c4c8f6941cf1"
+  },
+  {
+    "item_id": "d2189bca-0b13-451d-b70c-70ec43f7a207"
+  },
+  {
+    "item_id": "a9de17fb-57cf-442a-988c-8ab1ec79b3db"
+  },
+  {
+    "item_id": "ae85973e-7540-4027-b53a-ee41a249d124"
+  },
+  {
+    "item_id": "35094e1a-b385-47a6-a93f-67f8842992d6"
+  },
+  {
+    "item_id": "1151cad4-ce36-4944-96d3-e6062f1daf97"
+  },
+  {
+    "item_id": "a59a299c-28d1-4c41-9563-47faea69a0b7"
+  },
+  {
+    "item_id": "e2276407-cab7-48f6-8a4e-b981fbed0417"
+  },
+  {
+    "item_id": "268f9a5c-3a44-4ca8-b500-68fd045a2d47"
+  },
+  {
+    "item_id": "0c26d758-55c5-4591-9c4f-5f0d2a6cc347"
+  },
+  {
+    "item_id": "ce30f9ab-eef4-47c0-84e9-ffb704317314"
+  },
+  {
+    "item_id": "3f3b1ba5-ee90-4ece-b303-2c083010602e"
+  },
+  {
+    "item_id": "329c3ef3-1602-477e-9a38-e5becaf2aab1"
+  },
+  {
+    "item_id": "a1e767fe-7557-4092-8f54-2071617c89b3"
+  },
+  {
+    "item_id": "41624f5a-61da-4a5b-a347-5918dccfe3a9"
+  },
+  {
+    "item_id": "56bc0e93-0a95-40ce-b60e-7f50c6e41560"
+  },
+  {
+    "item_id": "db216954-cdc9-4253-a155-6e9c7a25cd39"
+  },
+  {
+    "item_id": "b82f509d-28c8-4859-afe4-a9d4e47538d0"
+  },
+  {
+    "item_id": "9b240369-ee8e-4d0d-8914-92bbb0145411"
+  },
+  {
+    "item_id": "35c2903a-687a-448d-b594-c46ee423989d"
+  },
+  {
+    "item_id": "11b9b0c3-6cde-450a-91b8-41e4bfc0a514"
+  },
+  {
+    "item_id": "5fdd7918-2122-4ff3-875c-0facf2bcd1f1"
+  },
+  {
+    "item_id": "40d80139-ee61-4eb1-9a66-eb3fba32430f"
+  },
+  {
+    "item_id": "3936cf7f-ef74-4203-9302-bcce349e9ca5"
+  },
+  {
+    "item_id": "c7becfa2-4e61-490a-838c-7b207956e21f"
+  },
+  {
+    "item_id": "e7a79828-6bc7-4b09-ac5a-4be76f4a18d4"
+  },
+  {
+    "item_id": "87cb487b-6922-4675-b3d9-9a6767bb5a1c"
+  },
+  {
+    "item_id": "4bf00d31-d65c-43fc-b95a-5caa3df0ac4b"
+  },
+  {
+    "item_id": "f3f500d5-d108-4f83-808e-e15ad520cce7"
+  },
+  {
+    "item_id": "4d4b233f-fba3-4e3e-9e80-fe79603a38b0"
+  },
+  {
+    "item_id": "6b8e7f04-ece2-4dd1-9256-4ce6881d3c11"
+  },
+  {
+    "item_id": "2a2b7699-5a1a-4379-8a33-3faf4badd512"
+  },
+  {
+    "item_id": "59a502dd-84c7-4ad1-9a78-7d042495a25b"
+  },
+  {
+    "item_id": "79f7ee1c-a798-4241-bc2a-902f8a16c548"
+  },
+  {
+    "item_id": "072421d7-7def-43b7-b3f8-441d735cba8c"
+  },
+  {
+    "item_id": "92c745cd-26fa-41e0-8b1b-a9827873af6e"
+  },
+  {
+    "item_id": "afadc638-f50b-42a3-a058-a475109ce9a7"
+  },
+  {
+    "item_id": "4a40cb13-61ed-461e-9117-57e3a530ab61"
+  },
+  {
+    "item_id": "9bd09566-0ba0-47a2-9400-a01a0e218e51"
+  },
+  {
+    "item_id": "6aea5335-d3b5-4c36-be35-8461d9206149"
+  },
+  {
+    "item_id": "28b10d91-030e-4828-b02e-4d173b8cfab9"
+  },
+  {
+    "item_id": "914dd414-184a-4d72-adfe-cea12e7a9fe4"
+  },
+  {
+    "item_id": "0304d95e-71f7-47c8-b415-5d6d2ffb5e85"
+  },
+  {
+    "item_id": "f281d4cb-864b-4afa-98be-67a773a5bbf5"
+  },
+  {
+    "item_id": "547cd24b-800d-406a-8608-62197c4a23f2"
+  },
+  {
+    "item_id": "92a3a3bb-1858-49c7-9a91-7750060fdedf"
+  },
+  {
+    "item_id": "fa1c0f13-5a61-40d8-8ac5-0c702578abd8"
+  },
+  {
+    "item_id": "75ae624e-fe9b-4705-9bc2-99066deeb214"
+  },
+  {
+    "item_id": "e769013d-619e-4180-8ca7-3960e1440ea1"
+  },
+  {
+    "item_id": "cb089afe-f076-4527-bb9a-342be41414e1"
+  },
+  {
+    "item_id": "8a17aa75-d002-4e09-bfdf-d5d38241950c"
+  },
+  {
+    "item_id": "1cc61fb9-22bb-476d-b133-c1c38d2e9f64"
+  },
+  {
+    "item_id": "438424a8-c55f-49c7-9860-683e805bc36e"
+  },
+  {
+    "item_id": "91e2a724-3253-43ec-8b62-bd6285d7895c"
+  },
+  {
+    "item_id": "9415f407-45c8-430e-b4e2-a6947848acaf"
+  },
+  {
+    "item_id": "c6752215-9ccb-4c67-b512-bd2cfdcaae86"
+  },
+  {
+    "item_id": "f114d011-5554-4169-8cca-d01512308bab"
+  },
+  {
+    "item_id": "9f51e626-4330-4ddd-984a-34e3b582b171"
+  },
+  {
+    "item_id": "ae0144fa-a8c5-416f-8c2c-02ae2ad11c79"
+  },
+  {
+    "item_id": "b1a7569d-c5e6-41d9-99ea-18c4b7e9105e"
+  },
+  {
+    "item_id": "c506e8b8-69f1-4f39-803a-6e3a34c06145"
+  },
+  {
+    "item_id": "067c467f-3922-40d0-a0e6-f35eafeaffc7"
+  },
+  {
+    "item_id": "681f1733-be53-4798-9198-6a1562783fd5"
+  },
+  {
+    "item_id": "bea672e3-d5bb-4008-9439-76fe914f46a7"
+  },
+  {
+    "item_id": "80e6cc62-73cd-4b55-bcbf-5770348ed843"
+  },
+  {
+    "item_id": "df1ee60b-5fb1-49a4-a0e8-1f05961ed250"
+  },
+  {
+    "item_id": "8104012c-3de8-4824-b11f-9bbaafff2408"
+  },
+  {
+    "item_id": "19c0f10d-e9a9-4f53-9f6f-08a106809a30"
+  },
+  {
+    "item_id": "818cfee5-06f3-4d25-b4b9-cafb65a57697"
+  },
+  {
+    "item_id": "60351f3f-c088-42df-819e-a3ad0c44772a"
+  },
+  {
+    "item_id": "b17769a4-33cf-476a-ab72-88760bf8e8ec"
+  },
+  {
+    "item_id": "bd4a7ce1-c702-4965-b9c4-01e0ffca352b"
+  },
+  {
+    "item_id": "8595c82d-ae75-4e7c-8e19-e7458849d61b"
+  },
+  {
+    "item_id": "fa46df66-4a9e-4500-8d64-270c723b1071"
+  },
+  {
+    "item_id": "8c52a558-78c4-4c5a-b06b-7d254af78db3"
+  },
+  {
+    "item_id": "de1fbb2e-47e5-4477-8b2c-533a82b479aa"
+  },
+  {
+    "item_id": "342a3884-6f24-4d2e-8a60-11d9ec06f5ee"
+  },
+  {
+    "item_id": "36658802-1c32-4af9-b41f-f2ce2adca813"
+  },
+  {
+    "item_id": "87167446-604f-4bda-b1b1-2f13ea712655"
+  },
+  {
+    "item_id": "6b64ad00-dbd7-4974-8e82-503c2faa9798"
+  },
+  {
+    "item_id": "3b88c9f8-870f-4b97-a9e3-34cf5fc5f118"
+  },
+  {
+    "item_id": "52d67205-01cc-4100-aee3-646795db6b95"
+  },
+  {
+    "item_id": "9d6a825b-75f7-4e63-8ada-4fa21202f843"
+  },
+  {
+    "item_id": "80b271ae-2668-4577-9512-f7562e651253"
+  },
+  {
+    "item_id": "6e9f2101-5cff-4356-95ea-43146f207fc5"
+  },
+  {
+    "item_id": "dbe7f7e3-229a-4d77-8d9f-7d857c051b54"
+  },
+  {
+    "item_id": "4880546f-66a5-461b-a3b0-c0e31379b23d"
+  },
+  {
+    "item_id": "2fae2fb9-686e-4b6e-a4e9-7cc28275bf44"
+  },
+  {
+    "item_id": "88162fa2-6b84-4c3e-82e8-9e4443cb11c0"
+  },
+  {
+    "item_id": "3f34d83f-f520-4bfa-a6a8-f08e3a0bea9d"
+  },
+  {
+    "item_id": "56870365-7dc4-4449-9f18-19caa0414b6b"
+  },
+  {
+    "item_id": "6d59f1d8-c073-47db-b3f5-0001878fd372"
+  },
+  {
+    "item_id": "88175c1a-8150-45f5-a1d8-d390457b9fe2"
+  },
+  {
+    "item_id": "dc304d16-2ec3-45b1-833b-a9536c1a7d95"
+  },
+  {
+    "item_id": "3052579c-dccc-46b8-8d93-bbecfa493992"
+  },
+  {
+    "item_id": "2cadbd86-48ec-4fab-95bb-5959818d5747"
+  },
+  {
+    "item_id": "5941ab41-5269-4401-9978-f6f389922443"
+  },
+  {
+    "item_id": "effc3ea9-0e61-4b47-ad1b-20782addb1bd"
+  },
+  {
+    "item_id": "980f0166-c073-42bc-a1df-7dab36421e10"
+  },
+  {
+    "item_id": "e5d47646-8715-43d3-a39b-23115255a1fe"
+  },
+  {
+    "item_id": "79ebe691-fe8b-46ea-806c-996919b730ca"
+  },
+  {
+    "item_id": "4a0c4c01-2597-4688-ac99-2726bb1a3505"
+  },
+  {
+    "item_id": "fe337d8c-3b02-4742-bfd0-59ac89d4234f"
+  },
+  {
+    "item_id": "cca40bed-4eaf-46c6-ae72-1e49ed3ef2ad"
+  },
+  {
+    "item_id": "6419c6a3-a47d-4ce5-93ef-11f17be5eecd"
+  },
+  {
+    "item_id": "5e66cfa3-c153-40ab-8cad-cb8aaf01d178"
+  },
+  {
+    "item_id": "680e9488-98e3-4a44-b462-761cf817ca10"
+  },
+  {
+    "item_id": "d14f3e75-4047-441e-a67b-fc0de042845a"
+  },
+  {
+    "item_id": "dac3ce68-bfe5-4774-8b89-fb4351d53445"
+  },
+  {
+    "item_id": "2f7b942d-1a59-40bc-bc92-a1e2e85803ee"
+  },
+  {
+    "item_id": "0cb16bc7-daff-4747-81e5-d4455d33fc43"
+  },
+  {
+    "item_id": "0dd3a72c-b43f-449a-92f3-fd25f164d224"
+  },
+  {
+    "item_id": "229aab36-08f5-4288-a9df-c804ad6c2b56"
+  },
+  {
+    "item_id": "b525113d-ce0a-4c11-b4d1-553eb3fef88d"
+  },
+  {
+    "item_id": "cf92e0a9-88ac-4fa8-9ecd-d61078868f26"
+  },
+  {
+    "item_id": "d110dc0e-7a78-42c3-8326-5b5ec58f8875"
+  },
+  {
+    "item_id": "14922be0-52bc-4711-9fc1-aeec98e39c1d"
+  },
+  {
+    "item_id": "37aa0f60-d86c-446d-848c-52b45777ae2c"
+  },
+  {
+    "item_id": "8379ada9-43de-4764-88b1-aa3d24b114fd"
+  },
+  {
+    "item_id": "afc97289-36f8-4acb-ab80-28e7770ea126"
+  },
+  {
+    "item_id": "98f65a4a-8501-45e4-bda8-48d5d01306ba"
+  },
+  {
+    "item_id": "e01d9c09-e66d-4fea-94e3-95db24137dd6"
+  },
+  {
+    "item_id": "4812042b-1d2a-4171-9a77-d2f0a0c44b91"
+  },
+  {
+    "item_id": "cb113ba3-eaa8-40e1-8ff8-a8b710bf89db"
+  },
+  {
+    "item_id": "5eca0d0a-81f6-4804-869f-32ed307adb9f"
+  },
+  {
+    "item_id": "8c1bc2c9-1eeb-4a19-ac6b-d11e2a7c6f63"
+  },
+  {
+    "item_id": "277652ec-bbeb-454c-85da-766438600d47"
+  },
+  {
+    "item_id": "318f9d08-d86a-4799-ac08-75014d089475"
+  },
+  {
+    "item_id": "0ea6b48d-d3a3-4969-a053-37d6e697de85"
+  },
+  {
+    "item_id": "fc550900-512d-4f82-b40a-25a8ef86d513"
+  },
+  {
+    "item_id": "d1d6e382-3b80-431e-ba08-5cbe1ccebce2"
+  },
+  {
+    "item_id": "7b281b2d-246c-4fec-bdf5-6eb92fbb8a34"
+  },
+  {
+    "item_id": "5230134e-6bfc-4a88-9cee-7bec1f15e099"
+  },
+  {
+    "item_id": "7fbe9c06-2e4a-4da4-aea0-45b4828f6687"
+  },
+  {
+    "item_id": "9c6d2c06-5031-414d-b743-850c4ddebdc3"
+  },
+  {
+    "item_id": "61846190-2e41-4590-95c0-172d767aacc1"
+  },
+  {
+    "item_id": "66851aee-1bf3-4b18-b1aa-50f79ce773f4"
+  },
+  {
+    "item_id": "d4c2f839-050c-4134-868d-eab325676917"
+  },
+  {
+    "item_id": "a89cb196-c162-4c49-b1d5-642547265f39"
+  },
+  {
+    "item_id": "ed19c2a7-fe9d-465b-b41a-71480e6b978a"
+  },
+  {
+    "item_id": "b93c9682-4e53-4a7f-a39b-79d57b2b4737"
+  },
+  {
+    "item_id": "68ff8b22-500f-4674-b9f0-b70414db12d8"
+  },
+  {
+    "item_id": "1282d538-71c9-4379-a330-820eccf83d22"
+  },
+  {
+    "item_id": "30fe522c-e827-436a-bd52-40314d80e95b"
+  },
+  {
+    "item_id": "2238849b-fcc8-4bd4-9828-66637c22f9af"
+  },
+  {
+    "item_id": "d65aaebc-e17b-421b-86e8-1cc9c63a0408"
+  },
+  {
+    "item_id": "cacf27d3-9206-414d-b28f-8745eec00a4a"
+  },
+  {
+    "item_id": "fc25e5f3-66d9-429d-8ca8-c1882a5083d6"
+  },
+  {
+    "item_id": "d506eda8-cab3-4046-b0b7-3c16fd1bc53d"
+  },
+  {
+    "item_id": "68f328f0-50d5-4152-aa9a-f5ab3c69f397"
+  },
+  {
+    "item_id": "e497ecb9-788c-476e-bb28-c1746fbff940"
+  },
+  {
+    "item_id": "ba7af9ee-e916-4d65-b7b2-c6afa2477ade"
+  },
+  {
+    "item_id": "7f54a4c5-d312-4b64-9d90-4945dd6d1b72"
+  },
+  {
+    "item_id": "63444a58-4cbd-4441-b5c3-5f216560e276"
+  },
+  {
+    "item_id": "d412d980-cc59-4a0b-ab9e-19100f3b8927"
+  },
+  {
+    "item_id": "f4d6ff64-87eb-466f-94a6-fbbaa28fab7d"
+  },
+  {
+    "item_id": "a38c18ee-88ab-46dd-994c-2c4e4d288d4c"
+  },
+  {
+    "item_id": "a4be83a4-b126-479a-bfca-81e7d612d2b3"
+  },
+  {
+    "item_id": "ef7fa499-a585-491d-9700-38962a125092"
+  },
+  {
+    "item_id": "b92200f5-9ac0-4104-9b0d-f444c55aceb8"
+  },
+  {
+    "item_id": "89612f07-abeb-400f-8bf1-0826601e17d1"
+  },
+  {
+    "item_id": "f6e1bdda-278a-4077-8d2f-49417303637f"
+  },
+  {
+    "item_id": "447b930e-7350-4ef3-80d4-2ec23a4c5708"
+  },
+  {
+    "item_id": "c3057e94-6b2a-4f19-b109-d6f7b17aefbe"
+  },
+  {
+    "item_id": "ef8bca4e-5627-4bde-a21f-9dae321ac7c0"
+  },
+  {
+    "item_id": "69dd67c0-ef9b-4a6c-9a60-2de96c36113a"
+  },
+  {
+    "item_id": "53831192-f7e2-4841-898f-f39f1cd9f1ff"
+  },
+  {
+    "item_id": "43c290f5-4178-431d-9874-5e24cde01299"
+  },
+  {
+    "item_id": "18ca5e39-fd8f-4739-95ef-9daaef6d525d"
+  },
+  {
+    "item_id": "4eb3e72f-dec7-445e-9cbe-5464f3df1ceb"
+  },
+  {
+    "item_id": "9cb9976f-4023-496c-9bdf-b5eff31fe5bb"
+  },
+  {
+    "item_id": "017d9ce1-f259-4d95-bffc-b3d44dfc8cde"
+  },
+  {
+    "item_id": "36e40f73-b836-49cd-a558-d93a238c7386"
+  },
+  {
+    "item_id": "3a1ac912-0af7-47cb-b540-1cb3efc46956"
+  },
+  {
+    "item_id": "6e75a3dc-d157-4f13-878c-5111cd6b03a2"
+  },
+  {
+    "item_id": "4096f192-ba2d-4a25-b1be-f3e4b0b40b51"
+  },
+  {
+    "item_id": "ba2b10d2-16a7-4036-8e8f-1fe0d113b0ac"
+  },
+  {
+    "item_id": "d0b170a0-b0c5-4d33-b3f2-e0e0dcac1872"
+  },
+  {
+    "item_id": "86f4fa21-5194-4439-a131-85c3a587a1fd"
+  },
+  {
+    "item_id": "096f02f7-0ce4-41ef-8896-f8209ca126f5"
+  },
+  {
+    "item_id": "49014ace-e742-49f8-887a-8fa7d1b627cc"
+  },
+  {
+    "item_id": "8576f0a6-2866-4ac7-af07-dffd8e4ea019"
+  },
+  {
+    "item_id": "76fb9740-07d0-45c8-a6b3-17534f293c54"
+  },
+  {
+    "item_id": "79a75489-f371-461e-8943-273f7b60e620"
+  },
+  {
+    "item_id": "2925c583-7c70-400d-8f50-f8c06b3dc0fb"
+  },
+  {
+    "item_id": "caa2a44c-fd86-4221-92ba-226a3834e0a4"
+  },
+  {
+    "item_id": "5e0ef28e-278a-48f1-92d1-256a37f76e47"
+  },
+  {
+    "item_id": "282a816f-1c0b-4efc-9939-0674020ee1ef"
+  },
+  {
+    "item_id": "67b88f7c-7b39-43ad-863a-0d03dd180faf"
+  },
+  {
+    "item_id": "803b6bf7-0cde-4a49-9e63-a117e95de2c0"
+  },
+  {
+    "item_id": "18f0f723-af8c-4415-9ea4-6578a641729a"
+  },
+  {
+    "item_id": "73443ff7-2113-490d-9249-430c95c1534a"
+  },
+  {
+    "item_id": "64356c91-6a6c-40d2-acd9-cbde11eaace4"
+  },
+  {
+    "item_id": "1d371a92-135a-4456-aca8-5537c9d53c81"
+  },
+  {
+    "item_id": "b4ecd378-f152-4049-b281-8b519cdb870d"
+  },
+  {
+    "item_id": "1c59d8b2-c755-4f10-859e-4847be81bc4c"
+  },
+  {
+    "item_id": "fce158e9-2134-4c57-bbc8-67483dc0b0d8"
+  },
+  {
+    "item_id": "4539d16d-f909-4fff-9eda-dc6763fa7a3b"
+  },
+  {
+    "item_id": "b7e3c6ef-7be3-4f63-b8ad-04affb29716c"
+  },
+  {
+    "item_id": "0c0d7114-9e80-4e4f-868d-51de6778bed1"
+  },
+  {
+    "item_id": "7812ff10-6f3d-4990-8832-9b5eb63780d8"
+  },
+  {
+    "item_id": "c38eff1e-2560-4373-a3d6-9e3ea04853ad"
+  },
+  {
+    "item_id": "e5b4d06d-c604-42fa-9329-e4bec9f44cfd"
+  },
+  {
+    "item_id": "2cf6bb87-842b-4d53-906d-6036d7e3eaf5"
+  },
+  {
+    "item_id": "df6d6cbf-58fc-49e6-a582-446c255a3d39"
+  },
+  {
+    "item_id": "91fb984c-4084-4b2c-84e5-ebda94169657"
+  },
+  {
+    "item_id": "103f9c4f-f4f9-4e15-98b2-0d2b1db6b792"
+  },
+  {
+    "item_id": "83c972be-a658-4858-9277-474eebee81a1"
+  },
+  {
+    "item_id": "d9100be3-bb0c-4ea5-9aff-3fa3b7946b12"
+  },
+  {
+    "item_id": "bcdee764-328b-440f-b1de-d4f4d4c14604"
+  },
+  {
+    "item_id": "97c03488-1331-4858-baf0-26e1d0fca6f0"
+  },
+  {
+    "item_id": "47521515-a430-41a1-bcdc-bb68b3f9d646"
+  },
+  {
+    "item_id": "0a6c62ed-f16b-4b57-8ff1-3984e08f204e"
+  },
+  {
+    "item_id": "7fe0f8aa-fbe1-4fef-bba3-e64b98b00bc2"
+  },
+  {
+    "item_id": "cb34566e-4c96-4191-9179-eca6bc9ac07f"
+  },
+  {
+    "item_id": "266098f6-079e-42d6-8d15-3a7867687f49"
+  },
+  {
+    "item_id": "ca367462-e3ba-4b03-9b46-05b7850bdcba"
+  },
+  {
+    "item_id": "cf489f8e-70b9-4669-8424-03e79fab2ad8"
+  },
+  {
+    "item_id": "7f406b9a-226a-4498-b708-59b14401a9af"
+  },
+  {
+    "item_id": "ef638662-6cfb-4335-9e01-baa7af9a5d95"
+  },
+  {
+    "item_id": "a7a257bb-3da8-42f1-b341-dad7221b9ab3"
+  },
+  {
+    "item_id": "cfa15026-8758-4249-b23c-fa41e23161c4"
+  },
+  {
+    "item_id": "66f3233f-afdd-49af-9cf4-cb71bcd56b33"
+  },
+  {
+    "item_id": "3e8fce57-40d7-4eec-9425-a2b32ef5895d"
+  },
+  {
+    "item_id": "3d49dcaa-90bd-4749-82a8-83a272d0864b"
+  },
+  {
+    "item_id": "3f740b1f-622f-4a43-a46c-6a0a13818292"
+  }
+]

--- a/src/bin/tweet.rs
+++ b/src/bin/tweet.rs
@@ -1,0 +1,174 @@
+extern crate getopts;
+extern crate egg_mode;
+extern crate read_rust;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate uuid;
+
+use getopts::Options;
+
+use read_rust::error::Error;
+use read_rust::feed::{Item, JsonFeed};
+use read_rust::toot_list::TootList;
+
+use std::io;
+use std::env;
+use std::fs::File;
+use std::path::Path;
+use std::collections::HashSet;
+
+const TWITTER_DATA_FILE: &str = ".twitter-data.json";
+
+struct AuthenticatedUser {
+    token: String,
+    user_id: u64,
+    screen_name: String,
+}
+
+struct TwitterData {
+    consumer_key: String,
+    consumer_secret: String,
+    user: Option<AuthenticatedUser>,
+}
+
+fn connect_to_twitter() -> Result<TwitterData, Error> {
+    let data = File::open(TWITTER_DATA_FILE).and_then(|file| {
+        serde_json::from_reader(file).map_err(Error::JsonError)
+    })?;
+
+    match data {
+        TwitterData { user: None } => register(data),
+        _ => Ok(data)
+    }
+}
+
+fn register2(mut data: TwitterData) {
+    let con_token = egg_mode::KeyPair::new(data.consumer_key, data.consumer_secret);
+    // "oob" is needed for PIN-based auth; see docs for `request_token` for more info
+    let request_token = core.run(egg_mode::request_token(&con_token, "oob", &handle)).unwrap();
+    let auth_url = egg_mode::authorize_url(&request_token);
+
+    // give auth_url to the user, they can sign in to Twitter and accept your app's permissions.
+    // they'll receive a PIN in return, they need to give this to your application
+    println!("Please visit this page and copy the PIN:\n{}", auth_url);
+
+    print!("Enter PIN: ");
+    let mut verifier = String::new();
+    io::stdin().read_line(&mut verifier).expect("error reading from stdin");
+
+    // note this consumes con_token; if you want to sign in multiple accounts, clone it here
+    let (token, user_id, screen_name) =
+        core.run(egg_mode::access_token(con_token, &request_token, verifier, &handle)).unwrap();
+
+    // token can be given to any egg_mode method that asks for a token
+    // user_id and screen_name refer to the user who signed in
+    data.user = Some(AuthenticatedUser { token, user_id, screen_name });
+
+    Ok(data)
+}
+
+fn register() -> Result<Mastodon, Error> {
+    let app = AppBuilder {
+        client_name: "read-rust",
+        redirect_uris: "urn:ietf:wg:oauth:2.0:oob",
+        scopes: Scopes::Write,
+        website: Some("https://readrust.net/"),
+    };
+
+    let mut registration = Registration::new("https://botsin.space");
+    registration.register(app).map_err(Error::Mastodon)?;
+    let url = registration.authorise().map_err(Error::Mastodon)?;
+
+    println!("Click this link to authorize on Mastodon: {}", url);
+    println!("Paste the returned authorization code: ");
+
+    let mut input = String::new();
+    let _ = io::stdin().read_line(&mut input).map_err(Error::Io)?;
+
+    let code = input.trim();
+    let mastodon = registration
+        .create_access_token(code.to_string())
+        .map_err(Error::Mastodon)?;
+
+    // Save app data for using on the next run.
+    let file = File::create(MASTODON_DATA_FILE).expect("Unable to create mastodon data file");
+    let _ = serde_json::to_writer_pretty(file, &*mastodon).map_err(Error::JsonError)?;
+
+    Ok(mastodon)
+}
+
+fn toot_text_from_item(item: &Item) -> String {
+    // Mastodon doesn't allow dashes in tags, which makes some of the longer tags a bit awkward. So
+    // leaving off for now.
+    // let tags = item.tags.iter()
+    //     .map(|tag| format!("#{}", tag.to_lowercase().replace(" ", "-")))
+    //     .collect::<Vec<String>>()
+    //     .join(" ");
+
+    format!(
+        "{title} by {author}: {url} #Rust",
+        title = item.title,
+        author = item.author.name,
+        url = item.url
+    )
+}
+
+fn run(tootlist_path: &str, json_feed_path: &str, dry_run: bool) -> Result<(), Error> {
+    let tootlist_path = Path::new(tootlist_path);
+    let mut tootlist = TootList::load(&tootlist_path)?;
+    let feed = JsonFeed::load(Path::new(json_feed_path))?;
+
+    let to_toot: Vec<Item> = feed.items
+        .into_iter()
+        .filter(|item| !tootlist.contains(&item.id))
+        .collect();
+
+    if to_toot.is_empty() {
+        println!("Nothing to toot!");
+        return Ok(());
+    }
+
+    let mastodon = connect_to_twitter()?;
+    for item in to_toot {
+        let status_text = toot_text_from_item(&item);
+        println!("• {}", status_text);
+        if !dry_run {
+            let _toot = mastodon
+                .new_status(StatusBuilder::new(status_text))
+                .map_err(Error::Mastodon)?;
+        }
+        tootlist.add_item(Toot { item_id: item.id });
+    }
+
+    if dry_run {
+        Ok(())
+    } else {
+        tootlist.save(&tootlist_path)
+    }
+}
+
+fn print_usage(program: &str, opts: &Options) {
+    let usage = format!("Usage: {} [options] tootlist.json jsonfeed.json", program);
+    print!("{}", opts.usage(&usage));
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "print this help menu");
+    opts.optflag("n", "dryrun", "don't toot, just show what would be tooted");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!(f.to_string()),
+    };
+    if matches.opt_present("h") || matches.free.is_empty() {
+        print_usage(&program, &opts);
+        return;
+    }
+
+    run(&matches.free[0], &matches.free[1], matches.opt_present("n")).expect("error");
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,26 @@
-extern crate reqwest;
-use serde_json;
 extern crate mammut;
+extern crate reqwest;
 extern crate rss;
 
 use std::io;
+use serde_json;
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
-    Reqwest(reqwest::Error),
-    Url(reqwest::UrlError),
+    #[fail(display = "HTTP error: {}", _0)]
+    Reqwest(#[cause] reqwest::Error),
+    #[fail(display = "URL error: {}", _0)]
+    Url(#[cause] reqwest::UrlError),
+    #[fail(display = "HTML parsing error")]
     HtmlParseError,
-    JsonError(serde_json::Error),
+    #[fail(display = "JSON parsing error: {}", _0)]
+    JsonError(#[cause] serde_json::Error),
+    #[fail(display = "{}", _0)]
     StringError(String),
-    RssError(rss::Error),
-    Io(io::Error),
-    Mastodon(mammut::Error),
+    #[fail(display = "RSS error: {}", _0)]
+    RssError(#[cause] rss::Error),
+    #[fail(display = "IO error: {}", _0)]
+    Io(#[cause] io::Error),
+    #[fail(display = "Mastodon error: {}", _0)]
+    Mastodon(#[cause] mammut::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,4 @@ pub enum Error {
     RssError(#[cause] rss::Error),
     #[fail(display = "IO error: {}", _0)]
     Io(#[cause] io::Error),
-    #[fail(display = "Mastodon error: {}", _0)]
-    Mastodon(#[cause] mammut::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ extern crate uuid;
 
 pub mod error;
 pub mod feed;
+pub mod toot_list;

--- a/src/toot_list.rs
+++ b/src/toot_list.rs
@@ -42,4 +42,3 @@ impl TootList {
         self.uuids.contains(uuid)
     }
 }
-

--- a/src/toot_list.rs
+++ b/src/toot_list.rs
@@ -1,0 +1,45 @@
+use std::fs::File;
+use std::path::Path;
+use std::collections::HashSet;
+
+use serde_json;
+use uuid::Uuid;
+
+use error::Error;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Toot {
+    pub item_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TootList {
+    toots: Vec<Toot>,
+    uuids: HashSet<Uuid>,
+}
+
+impl TootList {
+    pub fn load(path: &Path) -> Result<Self, Error> {
+        let toot_list = File::open(path).map_err(Error::Io)?;
+        let toots: Vec<Toot> = serde_json::from_reader(toot_list).map_err(Error::JsonError)?;
+        let uuids = toots.iter().map(|toot| toot.item_id.clone()).collect();
+
+        Ok(TootList { toots, uuids })
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), Error> {
+        let toot_list = File::create(path).map_err(Error::Io)?;
+        serde_json::to_writer_pretty(toot_list, &self.toots).map_err(Error::JsonError)
+    }
+
+    pub fn add_item(&mut self, item: Toot) {
+        let uuid = item.item_id.clone();
+        self.toots.push(item);
+        self.uuids.insert(uuid);
+    }
+
+    pub fn contains(&self, uuid: &Uuid) -> bool {
+        self.uuids.contains(uuid)
+    }
+}
+


### PR DESCRIPTION
Like the `toot` tool for Mastodon. This PR adds a `tweet` tool that tweets new posts. This will replace the current RSS->Twitter function performed by IFTTT. This has the following benefits:

- All new posts will be tweeted.
  - IFTTT only looks at RSS entries from the last week or so. When I add posts to the Read Rust feed I used a `date_published` of the original post. If I'm posting an older post IFTTT will not tweet it.
- Links will no longer be wrapped in a `ift.tt` URL redirect
- The tweet content can be completely controlled (possibly allowing for the category of the post to be added as a hash tag)