### PR TITLE
Add category hash tags to toots and tweets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: feeds
 	cobalt build
-	cargo run --release --bin toot -- -n content/_data/tooted.json content/_data/rust/posts.json
-	cargo run --release --bin tweet -- -n content/_data/tweeted.json content/_data/rust/posts.json
+	cargo run --release --bin toot -- -n content/_data/tooted.json content/_data/rust/posts.json content/_data/categories.json
+	cargo run --release --bin tweet -- -n content/_data/tweeted.json content/_data/rust/posts.json content/_data/categories.json
 
 feeds:
 	cargo build --release --bin generate-rss
@@ -22,5 +22,5 @@ feeds:
 
 deploy: all
 	aws s3 sync --delete --cache-control 'max-age=120, public' public s3://readrust.net
-	cargo run --release --bin toot -- content/_data/tooted.json content/_data/rust/posts.json
-	cargo run --release --bin tweet -- content/_data/tweeted.json content/_data/rust/posts.json
+	cargo run --release --bin toot -- content/_data/tooted.json content/_data/rust/posts.json content/_data/categories.json
+	cargo run --release --bin tweet -- content/_data/tweeted.json content/_data/rust/posts.json content/_data/categories.json

--- a/content/_data/categories.json
+++ b/content/_data/categories.json
@@ -1,15 +1,15 @@
 [
-  { "name": "Community", "path": "/community/", "description": "Initiatives in the Rust community." },
-  { "name": "Computer Science", "path": "/computer-science/", "description": "Covering data structures, algorithms, memory safety, etc." },
-  { "name": "Crates", "path": "/crates/", "description": "Notable new or updated crates." },
-  { "name": "DevOps and Deployment", "path": "/devops-and-deployment/", "description": "Building and deploying Rust, containerisation, continuous integration, etc." },
-  { "name": "Embedded", "path": "/embedded/", "description": "Rust on microcontrollers, IoT, devices." },
-  { "name": "Games and Graphics", "path": "/games-and-graphics/", "description": "Games built with Rust and other graphics related work." },
-  { "name": "Getting Started", "path": "/getting-started/", "description": "Introductory posts, guides and tutorials for getting started with Rust." },
-  { "name": "Language", "path": "/language/", "description": "General posts about the Rust language." },
-  { "name": "Operating Systems", "path": "/operating-systems/", "description": "Using Rust to build or explore operating systems." },
-  { "name": "Performance", "path": "/performance/", "description": "Optimisation, benchmarks, etc." },
-  { "name": "Rust 2018", "path": "/rust-2018/", "description": "Hopes and dreams for Rust in 2018." },
-  { "name": "Tools and Applications", "path": "/tools-and-applications/", "description": "Command line tools and GUI applications." },
-  { "name": "Web and Network Services", "path": "/web-and-network-services/", "description": "Web applications, web assembly, network daemons, etc." }
+  { "name": "Community", "hashtag": "community", "path": "/community/", "description": "Initiatives in the Rust community." },
+  { "name": "Computer Science", "hashtag": "compsci", "path": "/computer-science/", "description": "Covering data structures, algorithms, memory safety, etc." },
+  { "name": "Crates", "hashtag": "crates", "path": "/crates/", "description": "Notable new or updated crates." },
+  { "name": "DevOps and Deployment", "hashtag": "devops", "path": "/devops-and-deployment/", "description": "Building and deploying Rust, containerisation, continuous integration, etc." },
+  { "name": "Embedded", "hashtag": "embedded", "path": "/embedded/", "description": "Rust on microcontrollers, IoT, devices." },
+  { "name": "Games and Graphics", "hashtag": "games", "path": "/games-and-graphics/", "description": "Games built with Rust and other graphics related work." },
+  { "name": "Getting Started", "hashtag": "starting", "path": "/getting-started/", "description": "Introductory posts, guides and tutorials for getting started with Rust." },
+  { "name": "Language", "hashtag": "language", "path": "/language/", "description": "General posts about the Rust language." },
+  { "name": "Operating Systems", "hashtag": "os", "path": "/operating-systems/", "description": "Using Rust to build or explore operating systems." },
+  { "name": "Performance", "hashtag": "performance", "path": "/performance/", "description": "Optimisation, benchmarks, etc." },
+  { "name": "Rust 2018", "hashtag": "Rust2018", "path": "/rust-2018/", "description": "Hopes and dreams for Rust in 2018." },
+  { "name": "Tools and Applications", "hashtag": "tools", "path": "/tools-and-applications/", "description": "Command line tools and GUI applications." },
+  { "name": "Web and Network Services", "hashtag": "web", "path": "/web-and-network-services/", "description": "Web applications, web assembly, network daemons, etc." }
 ]

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -1,0 +1,49 @@
+use std::fs::File;
+use std::path::Path;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::borrow::Borrow;
+
+use serde_json;
+
+use error::Error;
+
+#[derive(Debug, Deserialize)]
+pub struct Category {
+    pub name: String,
+    pub hashtag: String,
+    pub path: String,
+    pub description: String,
+}
+
+#[derive(Debug)]
+pub struct Categories {
+    categories: Vec<Rc<Category>>,
+    tag_map: HashMap<String, Rc<Category>>,
+}
+
+impl Categories {
+    pub fn load(path: &Path) -> Result<Self, Error> {
+        let categories_file = File::open(path).map_err(Error::Io)?;
+        let categories: Vec<Category> =
+            serde_json::from_reader(categories_file).map_err(Error::JsonError)?;
+        let categories: Vec<_> = categories.into_iter().map(Rc::new).collect();
+
+        let mut tag_map = HashMap::new();
+        for category in categories.iter() {
+            tag_map.insert(category.name.clone(), Rc::clone(&category));
+        }
+
+        Ok(Categories {
+            categories,
+            tag_map,
+        })
+    }
+
+    pub fn hashtag_for_category(&self, category_name: &str) -> Option<&str> {
+        self.tag_map.get(category_name).map(|category| {
+            let cat: &Category = category.borrow();
+            cat.hashtag.as_ref()
+        })
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,18 +7,11 @@ use serde_json;
 
 #[derive(Debug, Fail)]
 pub enum Error {
-    #[fail(display = "HTTP error: {}", _0)]
-    Reqwest(#[cause] reqwest::Error),
-    #[fail(display = "URL error: {}", _0)]
-    Url(#[cause] reqwest::UrlError),
-    #[fail(display = "HTML parsing error")]
-    HtmlParseError,
-    #[fail(display = "JSON parsing error: {}", _0)]
-    JsonError(#[cause] serde_json::Error),
-    #[fail(display = "{}", _0)]
-    StringError(String),
-    #[fail(display = "RSS error: {}", _0)]
-    RssError(#[cause] rss::Error),
-    #[fail(display = "IO error: {}", _0)]
-    Io(#[cause] io::Error),
+    #[fail(display = "HTTP error: {}", _0)] Reqwest(#[cause] reqwest::Error),
+    #[fail(display = "URL error: {}", _0)] Url(#[cause] reqwest::UrlError),
+    #[fail(display = "HTML parsing error")] HtmlParseError,
+    #[fail(display = "JSON parsing error: {}", _0)] JsonError(#[cause] serde_json::Error),
+    #[fail(display = "{}", _0)] StringError(String),
+    #[fail(display = "RSS error: {}", _0)] RssError(#[cause] rss::Error),
+    #[fail(display = "IO error: {}", _0)] Io(#[cause] io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ extern crate uuid;
 pub mod error;
 pub mod feed;
 pub mod toot_list;
+pub mod categories;


### PR DESCRIPTION
It looks like people pretty [universally want or aren't opposed](https://twitter.com/read_rust/status/996869885551566848) to including category hash tags. This PR adds them to tweets and toots. Since the longer category names don't translate that well to hash tags shorter hash tag versions have been created. Will merge after the final Twitter poll results are in.

Closes #29