### PR TITLE
Link to my patreon page instead of liberapay

### DIFF
--- a/content/_data/creators.yaml
+++ b/content/_data/creators.yaml
@@ -351,8 +351,8 @@
     name: Philipp Oppermann
     avatar: phil-opp.png
     support:
-      name: Support on Liberapay
-      link: https://liberapay.com/phil-opp/
+      name: Support on Patreon
+      link: https://www.patreon.com/phil_opp
     code:
       name: 'phil-opp'
       link: https://github.com/phil-opp


### PR DESCRIPTION
Thanks a lot for putting me in the list!

In my experience, I get a lot more sponsors on Patreon than on Liberapay, so I would prefer if the link points there.