### PR TITLE
Add full text search for posts

### DIFF
--- a/crystal/src/actions/search/show.cr
+++ b/crystal/src/actions/search/show.cr
@@ -2,13 +2,14 @@ class Search::Show < BrowserAction
   include Auth::AllowGuests
 
   param q : String = ""
+  param page : Int32 = 1 # Trying to make this UInt16 or UInt32 gives Error: undefined constant UInt32::Lucky
 
   get "/search" do
     if q.blank?
       flash.failure = "You need to specify what to search for"
-      html Search::ShowPage, query: q, results: [] of SearchResult
+      html Search::ShowPage, query: q, results: SearchResults.none
     else
-      html Search::ShowPage, query: q, results: PostQuery.search(q)
+      html Search::ShowPage, query: q, results: PostQuery.search(q, Page.new(page))
     end
   end
 end

--- a/crystal/src/actions/search/show.cr
+++ b/crystal/src/actions/search/show.cr
@@ -6,9 +6,9 @@ class Search::Show < BrowserAction
   get "/search" do
     if q.blank?
       flash.failure = "You need to specify what to search for"
-      html Search::ShowPage, query: q, posts: PostQuery.new.none
+      html Search::ShowPage, query: q, results: [] of SearchResult
     else
-      html Search::ShowPage, query: q, posts: PostQuery.search(q).preload_post_categories.preload_tags
+      html Search::ShowPage, query: q, results: PostQuery.search(q)
     end
   end
 end

--- a/crystal/src/actions/search/show.cr
+++ b/crystal/src/actions/search/show.cr
@@ -1,0 +1,14 @@
+class Search::Show < BrowserAction
+  include Auth::AllowGuests
+
+  param q : String = ""
+
+  get "/search" do
+    if q.blank?
+      flash.failure = "You need to specify what to search for"
+      html Search::ShowPage, query: q, posts: PostQuery.new.none
+    else
+      html Search::ShowPage, query: q, posts: PostQuery.search(q).preload_post_categories.preload_tags
+    end
+  end
+end

--- a/crystal/src/components/posts/pagination.cr
+++ b/crystal/src/components/posts/pagination.cr
@@ -8,13 +8,13 @@ class Posts::Pagination < BaseComponent
 
   def render
     div class: "pagination" do
-      first_page
-      prev_page
+      first_page if total_pages > 2
+      prev_page if total_pages > 1
       span class: "pagination-link" do
         raw "Page #{@page}&nbsp;of&nbsp;#{total_pages}"
       end
-      next_page
-      last_page
+      next_page if total_pages > 1
+      last_page if total_pages > 2
     end
   end
 

--- a/crystal/src/components/posts/pagination.cr
+++ b/crystal/src/components/posts/pagination.cr
@@ -1,0 +1,61 @@
+class Posts::Pagination < BaseComponent
+  needs query : String
+  needs page : Page
+  needs total : UInt32
+  needs per_page : UInt16
+
+  @total_pages : UInt16?
+
+  def render
+    div class: "pagination" do
+      first_page
+      prev_page
+      span class: "pagination-link" do
+        raw "Page #{@page}&nbsp;of&nbsp;#{total_pages}"
+      end
+      next_page
+      last_page
+    end
+  end
+
+  private def prev_page
+    if @page.first?
+      span "← Previous", class: "pagination-link"
+    else
+      page_link "← Previous", @page.pred
+    end
+  end
+
+  private def next_page
+    if @page.to_u32 >= total_pages
+      span "Next →", class: "pagination-link"
+    else
+      page_link "Next →", @page.succ
+    end
+  end
+
+  private def first_page
+    if @page.first?
+      span "⇤ First", class: "pagination-link pagination-link-bounds"
+    else
+      page_link "⇤ First", 1, "pagination-link-bounds"
+    end
+  end
+
+  private def last_page
+    if @page.to_u32 == total_pages
+      span "Last ⇥", class: "pagination-link pagination-link-bounds"
+    else
+      page_link "Last ⇥", total_pages, "pagination-link-bounds"
+    end
+  end
+
+  private def page_link(text, page : UInt16, klass : String = "")
+    # FIXME: Don't hardcode the route helper
+    link text, to: Search::Show.with(q: @query, page: page.to_i), class: "pagination-link #{klass}"
+  end
+
+  private def total_pages : UInt16
+    @total_pages ||= (@total.to_f / @per_page.to_f).ceil.to_u16
+  end
+end

--- a/crystal/src/components/posts/summary.cr
+++ b/crystal/src/components/posts/summary.cr
@@ -11,13 +11,15 @@ class Posts::Summary < BaseComponent
 
   def render
     article do
-      a @post.title, href: @post.url
-      text " by #{@post.author}"
-      if @show_categories
-        text " in "
-        @post.post_categories.each_with_index do |cat, index|
-          text ", " if index != 0
-          link cat.name, to: Categories::Show.with(cat.slug)
+      div class: "article-meta" do
+        a @post.title, href: @post.url
+        text " by #{@post.author}"
+        if @show_categories
+          text " in "
+          @post.post_categories.each_with_index do |cat, index|
+            text ", " if index != 0
+            link cat.name, to: Categories::Show.with(cat.slug)
+          end
         end
       end
       tag "blockquote" do

--- a/crystal/src/components/posts/summary.cr
+++ b/crystal/src/components/posts/summary.cr
@@ -2,6 +2,12 @@ class Posts::Summary < BaseComponent
   needs post : Post
   needs current_user : User?
   needs show_categories : Bool = false
+  needs highlight : String? = nil
+
+  private SUBSTITUTIONS = {
+    '\u0012' => "<mark>",
+    '\u0014' => "</mark>",
+  }
 
   def render
     article do
@@ -15,7 +21,7 @@ class Posts::Summary < BaseComponent
         end
       end
       tag "blockquote" do
-        simple_format(HTML.escape(@post.summary))
+        simple_format(safe_summary)
       end
 
       @post.tags.each do |tag|
@@ -24,5 +30,10 @@ class Posts::Summary < BaseComponent
       end
       mount Posts::ActionBar.new(@post, @current_user)
     end
+  end
+
+  def safe_summary : String
+    summary = @highlight || @post.summary
+    HTML.escape(summary).gsub(SUBSTITUTIONS)
   end
 end

--- a/crystal/src/components/search/form.cr
+++ b/crystal/src/components/search/form.cr
@@ -1,0 +1,11 @@
+class Search::Form < BaseComponent
+  needs query : String = ""
+
+  def render
+    form action: "/search", class: "right", id: "search", method: "get" do
+      input aria_label: "Search Read Rust", autocapitalize: "off", autocomplete: "off", id: "q", maxlength: "255", name: "q", placeholder: "Search", title: "Search Read Rust", type: "search", value: @query
+      text " "
+      input type: "submit", value: "Search"
+    end
+  end
+end

--- a/crystal/src/components/search/form.cr
+++ b/crystal/src/components/search/form.cr
@@ -2,7 +2,7 @@ class Search::Form < BaseComponent
   needs query : String = ""
 
   def render
-    form action: "/search", class: "right", id: "search", method: "get" do
+    form action: "/search", class: "search-form", method: "get" do
       input aria_label: "Search Read Rust", autocapitalize: "off", autocomplete: "off", id: "q", maxlength: "255", name: "q", placeholder: "Search", title: "Search Read Rust", type: "search", value: @query
       text " "
       input type: "submit", value: "Search"

--- a/crystal/src/components/shared/header.cr
+++ b/crystal/src/components/shared/header.cr
@@ -1,15 +1,20 @@
 class Shared::Header < BaseComponent
   needs current_user : User?
+  needs query : String = ""
 
   def render
     current_user = @current_user
 
     header do
-      link to: Home::Index do
-        text "Read "
-        img alt: "", class: "logo", src: asset("images/logo.svg")
-        text " Rust"
+      div class: "logo-search-header #{@query.blank? ? "" : "logo-search-header-with-query"}" do
+        link to: Home::Index do
+          img alt: "", class: "logo", src: asset("images/logo.svg")
+          text "Read Rust"
+        end
+
+        mount Search::Form.new(@query)
       end
+
       nav do
         div class: "list-inline" do
           div do

--- a/crystal/src/css/app.scss
+++ b/crystal/src/css/app.scss
@@ -124,7 +124,7 @@ mark {
   }
 }
 .logo-search-header-with-query {
-  justify-content: center;
+  text-align: center;
 
   .search-form {
     display: none;
@@ -283,6 +283,18 @@ mark {
   clip: rect(1px, 1px, 1px, 1px);
 }
 
+.pagination {
+  text-align: center;
+  margin-top: 2em;
+  font-size: 1.1em;
+}
+.pagination-link {
+  padding-right: 1em;
+}
+a.pagination-link {
+  color: blue;
+}
+
 .search-form input[type="text"] {
   width: 20em;
 }
@@ -334,6 +346,9 @@ mark {
 @media (max-width: 460px) {
   .list-inline {
     flex-wrap: wrap;
+  }
+  .pagination-link-bounds {
+    display: none;
   }
 }
 

--- a/crystal/src/css/app.scss
+++ b/crystal/src/css/app.scss
@@ -82,6 +82,9 @@ nav a:hover, nav a:focus {
 article {
   margin-top: 2em;
 }
+.article-meta {
+  font-size: 1.1em;
+}
 blockquote {
   margin-left: 0;
   padding-left: 1em;

--- a/crystal/src/css/app.scss
+++ b/crystal/src/css/app.scss
@@ -59,6 +59,9 @@ header a {
   color: currentColor;
   text-decoration: none;
 }
+header .search-form {
+  text-align: right;
+}
 h1 a {
   color: currentColor;
   text-decoration: none;
@@ -277,9 +280,6 @@ mark {
   clip: rect(1px, 1px, 1px, 1px);
 }
 
-.search-form {
-  text-align: right;
-}
 .search-form input[type="text"] {
   width: 20em;
 }

--- a/crystal/src/css/app.scss
+++ b/crystal/src/css/app.scss
@@ -36,19 +36,24 @@ h1,h2,h3 {
   color: #333;
 }
 footer {
+  color: #ccc;
   text-align: center;
-  border-top: 1px solid #fbd492;
-  border-bottom: 1px solid #fbd492;
-  background-color: #fff9f2;
+  border-top: 2px solid #333;
+  border-bottom: 1px solid #111;
+  background-color: #444;
   padding: 1em;
   margin-top: 4em;
+}
+footer a {
+  color: #ccc;
 }
 header {
   font-size: 1.5em;
   font-weight: 500;
   color: black;
-  padding: 1em 1em 2em;
-  text-align: center;
+  background-color: #fff9f2;
+  border-bottom: 1px solid #fde8c4;
+  margin-bottom: 4em;
 }
 header a {
   color: currentColor;
@@ -58,6 +63,9 @@ h1 a {
   color: currentColor;
   text-decoration: none;
   border-bottom: 3px solid currentColor;
+}
+nav {
+  text-align: center;
 }
 nav a {
   font-size: 18px;
@@ -75,6 +83,10 @@ blockquote {
   margin-left: 0;
   padding-left: 1em;
   border-left: 3px solid #fde8c4;
+}
+mark {
+  background-color: #fffdfd;
+  font-weight: bold;
 }
 :target {
   background-color: #fff9f2;
@@ -94,11 +106,31 @@ blockquote {
 .list-inline .support {
   width: 6em;
 }
+.logo-search-header {
+  padding-top: 1.5em;
+  margin: 0 auto;
+  max-width: 750px;
+  display: flex;
+  justify-content: space-between;
+
+  input {
+    display: inline-block;
+    box-sizing: border-box;
+    height: 30px;
+  }
+}
+.logo-search-header-with-query {
+  justify-content: center;
+
+  .search-form {
+    display: none;
+  }
+}
 .logo {
   vertical-align: top;
   width: 50px;
   height: 40px;
-  margin: 0 0.5em;
+  margin: 0 0.5em 0.5em 0;
 }
 .heart {
   position: relative;
@@ -248,10 +280,7 @@ blockquote {
   clip: rect(1px, 1px, 1px, 1px);
 }
 
-#search {
-  margin-bottom: 2em;
-}
-#search input[type="text"] {
+.search-form input[type="text"] {
   width: 20em;
 }
 .socials {
@@ -264,7 +293,9 @@ blockquote {
 }
 
 @media (max-width: 768px) {
-  header {
+  .logo-search-header-inner {
+    justify-content: center;
+    flex-wrap: wrap;
     padding-bottom: 1em;
     padding-left: 10px;
     padding-bottom: 10px;

--- a/crystal/src/css/app.scss
+++ b/crystal/src/css/app.scss
@@ -113,10 +113,8 @@ mark {
   display: flex;
   justify-content: space-between;
 
-  input {
-    display: inline-block;
-    box-sizing: border-box;
-    height: 30px;
+  & > * {
+    flex: 1 0 auto;
   }
 }
 .logo-search-header-with-query {
@@ -242,7 +240,6 @@ mark {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  /* border: 1px solid #ffebd4; */
   border-radius: 3px;
   margin: 1.5em 0;
 }
@@ -280,6 +277,9 @@ mark {
   clip: rect(1px, 1px, 1px, 1px);
 }
 
+.search-form {
+  text-align: right;
+}
 .search-form input[type="text"] {
   width: 20em;
 }
@@ -293,18 +293,39 @@ mark {
 }
 
 @media (max-width: 768px) {
-  .logo-search-header-inner {
-    justify-content: center;
-    flex-wrap: wrap;
-    padding-bottom: 1em;
-    padding-left: 10px;
-    padding-bottom: 10px;
-  }
   .main {
     margin-top: 0;
   }
+  .logo {
+    padding-left: 0.5em;
+  }
+  .search-form {
+    padding-right: 0.5em;
+
+    input {
+      font-size: 16px;
+    }
+  }
   .feedicon {
     margin-top: 1em;
+  }
+}
+@media (max-width: 570px) {
+  header {
+    text-align: center;
+    margin-bottom: 1em;
+
+    .logo-search-header {
+      justify-content: center;
+      flex-wrap: wrap;
+      padding-bottom: 1em;
+      padding-left: 10px;
+      padding-bottom: 10px;
+    }
+    .search-form {
+      text-align: center;
+      margin-top: 0.5em;
+    }
   }
 }
 @media (max-width: 460px) {

--- a/crystal/src/models/page.cr
+++ b/crystal/src/models/page.cr
@@ -1,0 +1,18 @@
+# A type representing a page number
+#
+# Will always be in the range 1..=UInt16::MAX
+struct Page
+  delegate to_i, to_u16, to_u32, to_s, succ, pred, to: @page
+
+  def initialize(page)
+    if page < 1 || page > UInt16::MAX
+      @page = 1_u16
+    else
+      @page = page.to_u16
+    end
+  end
+
+  def first?
+    @page == 1_u16
+  end
+end

--- a/crystal/src/models/search_result.cr
+++ b/crystal/src/models/search_result.cr
@@ -1,0 +1,7 @@
+class SearchResult
+  getter post
+  getter summary
+
+  def initialize(@post : Post, @summary : String)
+  end
+end

--- a/crystal/src/models/search_results.cr
+++ b/crystal/src/models/search_results.cr
@@ -1,0 +1,16 @@
+class SearchResults
+  getter results
+  getter total
+  getter page
+
+  def self.none
+    new([] of SearchResult, Page.new(1), 0)
+  end
+
+  def initialize(@results : Array(SearchResult), @page : Page, @total : UInt32)
+  end
+
+  def empty?
+    @total == 0
+  end
+end

--- a/crystal/src/operations/save_post.cr
+++ b/crystal/src/operations/save_post.cr
@@ -6,7 +6,6 @@ class SavePost < Post::SaveOperation
   before_save assign_guid
   before_save validate_tags
   before_save validate_url
-  after_commit refresh_full_text_index
 
   private def assign_guid
     guid.value ||= UUID.random
@@ -22,9 +21,5 @@ class SavePost < Post::SaveOperation
     if (url.value || "").includes?("utm_source")
       url.add_error "must not contain tracking parameters"
     end
-  end
-
-  private def refresh_full_text_index(_newly_created_post : Post)
-    AppDatabase.run(&.exec "REFRESH MATERIALIZED VIEW search_view")
   end
 end

--- a/crystal/src/operations/save_post.cr
+++ b/crystal/src/operations/save_post.cr
@@ -6,6 +6,7 @@ class SavePost < Post::SaveOperation
   before_save assign_guid
   before_save validate_tags
   before_save validate_url
+  after_commit refresh_full_text_index
 
   private def assign_guid
     guid.value ||= UUID.random
@@ -21,5 +22,9 @@ class SavePost < Post::SaveOperation
     if (url.value || "").includes?("utm_source")
       url.add_error "must not contain tracking parameters"
     end
+  end
+
+  private def refresh_full_text_index(_newly_created_post : Post)
+    AppDatabase.run(&.exec "REFRESH MATERIALIZED VIEW search_view")
   end
 end

--- a/crystal/src/operations/search_data.cr
+++ b/crystal/src/operations/search_data.cr
@@ -1,0 +1,9 @@
+class SearchData < Avram::Operation
+  attribute q : String = ""
+
+  def submit
+    validate_required q
+
+    yield self, PostQuery.search(q.value)
+  end
+end

--- a/crystal/src/pages/main_layout.cr
+++ b/crystal/src/pages/main_layout.cr
@@ -33,15 +33,13 @@ abstract class MainLayout
       mount Shared::LayoutHead.new(page_title: page_title, page_description: page_description, context: @context, categories: CategoryQuery.new, app_js: app_js?, admin: admin?, extra_css: extra_css)
 
       body do
-        mount Shared::Header.new(@current_user)
+        mount Shared::Header.new(@current_user, @query)
         mount Shared::FlashMessages.new(@context.flash)
         main class: "main" do
           h1 page_title
           content
         end
         footer do
-          mount Search::Form.new(@query)
-
           text " Copyright © 2018–#{Time.utc.year} "
           a "Wesley Moore", href: "https://www.wezm.net/about/"
           text ". Read Rust is not an official Rust or Mozilla project."

--- a/crystal/src/pages/main_layout.cr
+++ b/crystal/src/pages/main_layout.cr
@@ -4,6 +4,11 @@ abstract class MainLayout
   # 'needs current_user : User' makes it so that the current_user
   # is always required for pages using MainLayout
   needs current_user : User?
+  # FIXME: Enable when there's a Lucky release with this fix in it
+  # https://github.com/luckyframework/lucky/pull/993
+  # needs query : String = ""
+
+  @query : String = ""
 
   abstract def content
   abstract def page_title
@@ -35,14 +40,8 @@ abstract class MainLayout
           content
         end
         footer do
-          form action: "https://duckduckgo.com/", class: "right", id: "search", method: "get" do
-            input name: "sites", type: "hidden", value: "readrust.net"
-            input name: "kz", type: "hidden", value: "-1"
-            input name: "kaf", type: "hidden", value: "1"
-            input aria_label: "Search Read Rust", autocapitalize: "off", autocomplete: "off", id: "q", maxlength: "255", name: "q", placeholder: "Search", title: "Search Read Rust", type: "search"
-            text " "
-            input type: "submit", value: "Search"
-          end
+          mount Search::Form.new(@query)
+
           text " Copyright © 2018–#{Time.utc.year} "
           a "Wesley Moore", href: "https://www.wezm.net/about/"
           text ". Read Rust is not an official Rust or Mozilla project."

--- a/crystal/src/pages/posts/index_page.cr
+++ b/crystal/src/pages/posts/index_page.cr
@@ -19,6 +19,10 @@ class Posts::IndexPage < MainLayout
         li do
           a post.title, href: post.url
           text " by #{post.author}"
+          @current_user.try do
+            text " — "
+            link "Edit", Posts::Edit.with(post.id)
+          end
         end
       end
     end

--- a/crystal/src/pages/search/show_page.cr
+++ b/crystal/src/pages/search/show_page.cr
@@ -1,0 +1,21 @@
+class Search::ShowPage < MainLayout
+  needs query : String
+  needs posts : PostQuery
+
+  quick_def page_title, "Search Results"
+  quick_def page_description, ""
+
+  def content
+    mount Search::Form.new(@query)
+
+    count = 0
+    @posts.each do |post|
+      count += 1
+      mount Posts::Summary.new(post, @current_user, show_categories: true)
+    end
+
+    if count.zero?
+      para "No results were found."
+    end
+  end
+end

--- a/crystal/src/pages/search/show_page.cr
+++ b/crystal/src/pages/search/show_page.cr
@@ -1,6 +1,6 @@
 class Search::ShowPage < MainLayout
   needs query : String
-  needs results : Array(SearchResult)
+  needs results : SearchResults
 
   quick_def page_title, "Search Results"
   quick_def page_description, ""
@@ -11,9 +11,11 @@ class Search::ShowPage < MainLayout
     if @results.empty?
       para "No results were found."
     else
-      @results.each do |result|
+      @results.results.each do |result|
         mount Posts::Summary.new(result.post, @current_user, show_categories: true, highlight: result.summary)
       end
+
+      mount Posts::Pagination.new(query: @query, page: @results.page, per_page: PostQuery::PER_PAGE.to_u16, total: @results.total)
     end
   end
 end

--- a/crystal/src/pages/search/show_page.cr
+++ b/crystal/src/pages/search/show_page.cr
@@ -1,6 +1,6 @@
 class Search::ShowPage < MainLayout
   needs query : String
-  needs posts : PostQuery
+  needs results : Array(SearchResult)
 
   quick_def page_title, "Search Results"
   quick_def page_description, ""
@@ -8,14 +8,12 @@ class Search::ShowPage < MainLayout
   def content
     mount Search::Form.new(@query)
 
-    count = 0
-    @posts.each do |post|
-      count += 1
-      mount Posts::Summary.new(post, @current_user, show_categories: true)
-    end
-
-    if count.zero?
+    if @results.empty?
       para "No results were found."
+    else
+      @results.each do |result|
+        mount Posts::Summary.new(result.post, @current_user, show_categories: true, highlight: result.summary)
+      end
     end
   end
 end

--- a/crystal/src/queries/post_query.cr
+++ b/crystal/src/queries/post_query.cr
@@ -1,5 +1,7 @@
 class PostQuery < Post::BaseQuery
   PER_PAGE = 20
+  DC2 = '\u0012'
+  DC4 = '\u0014'
 
   def recent_in_category(category)
     if category.all?
@@ -13,16 +15,32 @@ class PostQuery < Post::BaseQuery
     recent_in_category(category).updated_at.select_max
   end
 
-  def self.search(query)
+  def self.search(query) : Array(SearchResult)
+    results = execute_search(query)
+    ids = results.map { |result| result[:id] }
+    id_to_post = {} of Int64 => Post
+    PostQuery.new.id.in(ids).preload_post_categories.preload_tags.each do |post|
+      id_to_post[post.id] = post
+    end
+
+    results.map do |result|
+      post = id_to_post[result[:id]]
+      next if post.nil?
+      SearchResult.new(post, result[:summary])
+    end.compact
+  end
+
+  private def self.execute_search(query) : Array({id: Int64, summary: String})
     sql = <<-SQL
-      SELECT id from search_view
+      SELECT
+        id,
+        ts_headline('english', summary, websearch_to_tsquery('english', $1), 'HighlightAll = true, StartSel = "#{DC2}", StopSel = "#{DC4}"')
+      FROM search_view
       WHERE vector @@ websearch_to_tsquery('english', $1) limit #{PER_PAGE}
     SQL
 
-    ids = AppDatabase.run do |db|
-      db.query_all sql, query, &.read(Int64)
+    AppDatabase.run do |db|
+      db.query_all sql, query, as: {id: Int64, summary: String}
     end
-
-    PostQuery.new.id.in(ids)
   end
 end

--- a/crystal/src/queries/post_query.cr
+++ b/crystal/src/queries/post_query.cr
@@ -1,4 +1,6 @@
 class PostQuery < Post::BaseQuery
+  PER_PAGE = 20
+
   def recent_in_category(category)
     if category.all?
       created_at.desc_order
@@ -9,5 +11,18 @@ class PostQuery < Post::BaseQuery
 
   def last_modified_in_category(category)
     recent_in_category(category).updated_at.select_max
+  end
+
+  def self.search(query)
+    sql = <<-SQL
+      SELECT id from search_view
+      WHERE vector @@ websearch_to_tsquery('english', $1) limit #{PER_PAGE}
+    SQL
+
+    ids = AppDatabase.run do |db|
+      db.query_all sql, query, &.read(Int64)
+    end
+
+    PostQuery.new.id.in(ids)
   end
 end

--- a/crystal/src/queries/post_query.cr
+++ b/crystal/src/queries/post_query.cr
@@ -1,5 +1,5 @@
 class PostQuery < Post::BaseQuery
-  PER_PAGE = 20
+  PER_PAGE = 10_u16
   DC2 = '\u0012'
   DC4 = '\u0014'
 
@@ -15,32 +15,49 @@ class PostQuery < Post::BaseQuery
     recent_in_category(category).updated_at.select_max
   end
 
-  def self.search(query) : Array(SearchResult)
-    results = execute_search(query)
+  def self.search(query : String, page : Page) : SearchResults
+    results = execute_search(query, page)
+    total = execute_search_total(query)
+
     ids = results.map { |result| result[:id] }
     id_to_post = {} of Int64 => Post
     PostQuery.new.id.in(ids).preload_post_categories.preload_tags.each do |post|
       id_to_post[post.id] = post
     end
 
-    results.map do |result|
+    post_results = results.map do |result|
       post = id_to_post[result[:id]]
       next if post.nil?
       SearchResult.new(post, result[:summary])
     end.compact
+    SearchResults.new(post_results, page, total.to_u32)
   end
 
-  private def self.execute_search(query) : Array({id: Int64, summary: String})
+  private def self.execute_search(query : String, page : Page) : Array({id: Int64, summary: String})
     sql = <<-SQL
       SELECT
         id,
         ts_headline('english', summary, websearch_to_tsquery('english', $1), 'HighlightAll = true, StartSel = "#{DC2}", StopSel = "#{DC4}"')
       FROM search_view
-      WHERE vector @@ websearch_to_tsquery('english', $1) limit #{PER_PAGE}
+      WHERE vector @@ websearch_to_tsquery('english', $1)
+      OFFSET #{(page.to_i - 1) * PER_PAGE}
+      LIMIT #{PER_PAGE}
     SQL
 
     AppDatabase.run do |db|
       db.query_all sql, query, as: {id: Int64, summary: String}
+    end
+  end
+
+  private def self.execute_search_total(query : String) : Int64
+    sql = <<-SQL
+      SELECT count(id)
+      FROM search_view
+      WHERE vector @@ websearch_to_tsquery('english', $1)
+    SQL
+
+    AppDatabase.run do |db|
+      db.query_one sql, query, as: Int64
     end
   end
 end

--- a/rust/migrations/2020-01-06-035808_add_full_text_index/down.sql
+++ b/rust/migrations/2020-01-06-035808_add_full_text_index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX search_index;
+DROP MATERIALIZED VIEW search_view;

--- a/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
+++ b/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
@@ -2,12 +2,12 @@ CREATE MATERIALIZED VIEW search_view AS
     SELECT posts.id,
            posts.summary,
            setweight(to_tsvector('english', posts.title), 'A') ||
-               setweight(to_tsvector('english', string_agg(' ', tags.name)), 'B') ||
+               setweight(to_tsvector('english', coalesce(string_agg(tags.name, ' '), '')), 'B') ||
                setweight(to_tsvector('english', posts.summary), 'C') ||
                setweight(to_tsvector('english', posts.author), 'D') AS vector
     FROM posts
-    LEFT JOIN post_tags ON (post_tags.post_id = posts.id)
-    LEFT JOIN tags ON (tags.id = post_tags.tag_id)
+    LEFT JOIN post_tags ON (posts.id = post_tags.post_id)
+    LEFT JOIN tags ON (post_tags.tag_id = tags.id)
     GROUP BY posts.id;
 
 CREATE INDEX search_index ON search_view USING GIN (vector);

--- a/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
+++ b/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
@@ -1,0 +1,10 @@
+CREATE MATERIALIZED VIEW search_view AS
+    SELECT posts.id, setweight(to_tsvector('english', posts.title), 'A') ||
+                     setweight(to_tsvector('english', string_agg(' ', tags.name)), 'B') ||
+                     setweight(to_tsvector('english', posts.summary), 'C') AS vector
+    FROM posts
+    LEFT JOIN post_tags ON (post_tags.post_id = posts.id)
+    LEFT JOIN tags ON (tags.id = post_tags.tag_id)
+    GROUP BY posts.id;
+
+CREATE INDEX search_index ON search_view USING GIN (vector);

--- a/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
+++ b/rust/migrations/2020-01-06-035808_add_full_text_index/up.sql
@@ -1,7 +1,10 @@
 CREATE MATERIALIZED VIEW search_view AS
-    SELECT posts.id, setweight(to_tsvector('english', posts.title), 'A') ||
-                     setweight(to_tsvector('english', string_agg(' ', tags.name)), 'B') ||
-                     setweight(to_tsvector('english', posts.summary), 'C') AS vector
+    SELECT posts.id,
+           posts.summary,
+           setweight(to_tsvector('english', posts.title), 'A') ||
+               setweight(to_tsvector('english', string_agg(' ', tags.name)), 'B') ||
+               setweight(to_tsvector('english', posts.summary), 'C') ||
+               setweight(to_tsvector('english', posts.author), 'D') AS vector
     FROM posts
     LEFT JOIN post_tags ON (post_tags.post_id = posts.id)
     LEFT JOIN tags ON (tags.id = post_tags.tag_id)


### PR DESCRIPTION
Implements search using PostgreSQL full text search features. Posts are indexed by title, tags, summary, and author. Search queries support a small number of operations (provided by `websearch_to_ts_query`: 

- `unquoted text`: words are ANDed
- `"quoted text"`: exact match
- `OR`: logical OR
- `-`: the logical not operator, excludes matches with this word
