### PR TITLE
Fix escaping of post summaries

### DIFF
--- a/crystal/spec/components/posts/summary_spec.cr
+++ b/crystal/spec/components/posts/summary_spec.cr
@@ -1,0 +1,33 @@
+require "../../spec_helper"
+
+include ContextHelper
+
+private class TestMountPage
+  include Lucky::HTMLPage
+
+  needs summary : String
+
+  def render
+    mount Posts::Summary.new(post: post, current_user: nil, show_categories: true, highlight: nil)
+    view
+  end
+
+  private def post
+    post = PostBox.create &.summary(@summary)
+    PostQuery.new.preload_post_categories.preload_tags.find(post.id)
+  end
+end
+
+describe Posts::Summary do
+  context "render" do
+    it "escapes the summary" do
+      contents = TestMountPage.new(summary: "I've Rc<RefCell<T>>", context: build_context).render.to_s
+      contents.should contain("<blockquote><p>I&#39;ve Rc&lt;RefCell&lt;T&gt;&gt;</p></blockquote>")
+    end
+
+    it "replaces DC2 and DC4 characters with mark tags" do
+      contents = TestMountPage.new(summary: "This \u{0012}keyword\u{0014} matches", context: build_context).render.to_s
+      contents.should contain("<blockquote><p>This <mark>keyword</mark> matches</p></blockquote>")
+    end
+  end
+end

--- a/crystal/spec/support/boxes/post_box.cr
+++ b/crystal/spec/support/boxes/post_box.cr
@@ -1,0 +1,9 @@
+class PostBox < Avram::Box
+  def initialize
+    guid UUID.random(Random.new, UUID::Variant::RFC4122, UUID::Version::V4)
+    title "Test"
+    url "https://example.com/"
+    author "Test Suite"
+    summary "Summary"
+  end
+end

--- a/crystal/spec/support/context_helper.cr
+++ b/crystal/spec/support/context_helper.cr
@@ -1,0 +1,58 @@
+# https://github.com/luckyframework/lucky/blob/685e0ca20f0b06784e7df4a1722e68addbbbd312/spec/support/context_helper.cr
+
+module ContextHelper
+  extend self
+
+  private def build_request(
+    method = "GET",
+    body = "",
+    content_type = "",
+    fixed_length : Bool = false
+  ) : HTTP::Request
+    headers = HTTP::Headers.new
+    headers.add("Content-Type", content_type)
+    if fixed_length
+      body = HTTP::FixedLengthContent.new(IO::Memory.new(body), body.size)
+    end
+    HTTP::Request.new(method, "/", body: body, headers: headers)
+  end
+
+  def build_context(
+    path = "/",
+    request : HTTP::Request? = nil
+  ) : HTTP::Server::Context
+    build_context_with_io(IO::Memory.new, path: path, request: request)
+  end
+
+  def build_context(request : HTTP::Request) : HTTP::Server::Context
+    build_context(path: "/", request: request)
+  end
+
+  private def build_context(method : String) : HTTP::Server::Context
+    build_context_with_io(
+      IO::Memory.new,
+      path: "/",
+      request: build_request(method)
+    )
+  end
+
+  private def build_context_with_io(
+    io : IO,
+    path = "/",
+    request = nil
+  ) : HTTP::Server::Context
+    request = request || HTTP::Request.new("GET", path)
+    response = HTTP::Server::Response.new(io)
+    HTTP::Server::Context.new request, response
+  end
+
+  private def build_context_with_flash(flash : String)
+    build_context.tap do |context|
+      context.session.set(Lucky::FlashStore::SESSION_KEY, flash)
+    end
+  end
+
+  private def params
+    {} of String => String
+  end
+end

--- a/crystal/src/components/posts/summary.cr
+++ b/crystal/src/components/posts/summary.cr
@@ -23,7 +23,7 @@ class Posts::Summary < BaseComponent
         end
       end
       tag "blockquote" do
-        simple_format(safe_summary)
+        simple_format(safe_summary, escape: false)
       end
 
       @post.tags.each do |tag|


### PR DESCRIPTION
One of the prior updates caused the summaries to be double escaped.